### PR TITLE
Fix for both unix & windows compatability

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@
 
     Constangular.prototype.type = 'javascript';
 
-    Constangular.prototype.pattern = /config\/.*\.yaml$/;
+    Constangular.prototype.pattern = /config(\\|\/).*\.yaml$/;
 
     function Constangular(config) {
       this.config = config;


### PR DESCRIPTION
The previously committed windows fix changed the src/index.coffee ... But `package.json` specifies to run from `/lib/index`. The proposed change here should work for either unix or windows
